### PR TITLE
Fix list data by sensor

### DIFF
--- a/src/data/DataStore.js
+++ b/src/data/DataStore.js
@@ -46,6 +46,7 @@ class DataStore {
     if (queryBase.from && queryBase.sensorId) {
       const sensorId = parseInt(queryBase.sensorId, 10);
       queryBase.$and = [{ from: queryBase.from }, { 'payload.sensorId': sensorId }];
+      delete queryBase.sensorId;
     }
 
     if (queryBase.deviceIds) {


### PR DESCRIPTION
This patch will avoid the endpoint /data/<device_id>/sensor/<sensor_id>
from return an empty array. The sensorId property wasn't removed
after being used to create an $and query, causing the query not to
match any document on database.