### PR TITLE
Doc fixes and config adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A development container is specified at `docker/Dockerfile-dev`. To use it, exec
 01. Build the image:
 
     ```bash
-    docker build . -f docker/Dockerfile-dev -t cesarbr/knot-cloud-storage:dev
+    docker build . -f docker/Dockerfile-dev -t cesarbr/knot-cloud-storage-go:dev
     ```
 
 01. Create a file containing the configuration as environment variables.
@@ -72,7 +72,7 @@ A development container is specified at `docker/Dockerfile-dev`. To use it, exec
 01. Run the container:
 
     ```bash
-    docker run --env-file knot-cloud-storage.env -p 8080:80 -v `pwd`:/usr/src/app -ti cesarbr/knot-cloud-storage:dev
+    docker run --env-file knot-cloud-storage.env -p 8080:80 -v `pwd`:/usr/src/app -ti cesarbr/knot-cloud-storage-go:dev
     ```
 
 The first argument to -v must be the root of this repository, so if you are running from another folder, replace `pwd` with the corresponding path.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A container is specified at `docker/Dockerfile`. To use it, execute the followin
 01. Build the image:
 
     ```bash
-    docker build . -f docker/Dockerfile -t cesarbr/knot-babeltower
+    docker build . -f docker/Dockerfile -t cesarbr/knot-cloud-storage
     ```
 
 01. Create a file containing the configuration as environment variables.
@@ -54,7 +54,7 @@ A container is specified at `docker/Dockerfile`. To use it, execute the followin
 01. Run the container:
 
     ```bash
-    docker run --env-file knot-babeltower.env -ti cesarbr/knot-babeltower
+    docker run --env-file knot-cloud-storage.env -ti cesarbr/knot-cloud-storage
     ```
 
 #### Development
@@ -64,7 +64,7 @@ A development container is specified at `docker/Dockerfile-dev`. To use it, exec
 01. Build the image:
 
     ```bash
-    docker build . -f docker/Dockerfile-dev -t cesarbr/knot-babeltower:dev
+    docker build . -f docker/Dockerfile-dev -t cesarbr/knot-cloud-storage:dev
     ```
 
 01. Create a file containing the configuration as environment variables.
@@ -72,7 +72,7 @@ A development container is specified at `docker/Dockerfile-dev`. To use it, exec
 01. Run the container:
 
     ```bash
-    docker run --env-file knot-babeltower.env -p 8080:80 -v `pwd`:/usr/src/app -ti cesarbr/knot-babeltower:dev
+    docker run --env-file knot-cloud-storage.env -p 8080:80 -v `pwd`:/usr/src/app -ti cesarbr/knot-cloud-storage:dev
     ```
 
 The first argument to -v must be the root of this repository, so if you are running from another folder, replace `pwd` with the corresponding path.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,7 @@ func main() {
 	logrus := logging.NewLogrus(config.Logger.Level)
 
 	logger := logrus.Get("Main")
-	logger.Info("Starting KNoT Babeltower")
+	logger.Info("Starting KNoT Cloud Storage")
 
 	server := server.NewServer(config.Server.Port, logrus.Get("Server"))
 	server.Start()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG GOARCH
 ARG GOARM
 
 # Set the Current Working Directory inside the container
-WORKDIR /go/src/github.com/CESARBR/knot-babeltower
+WORKDIR /go/src/github.com/CESARBR/knot-cloud-storage
 
 # Copy the source code from the current directory to $WORKDIR (inside the container)
 COPY . .
@@ -35,12 +35,12 @@ FROM scratch
 WORKDIR /root/
 
 # Copy the configuration files from the build stage
-COPY --from=builder /go/src/github.com/CESARBR/knot-babeltower/internal/ ./internal
+COPY --from=builder /go/src/github.com/CESARBR/knot-cloud-storage/internal/ ./internal
 
 # Copy SSL CA certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy the binary file from the build stage
-COPY --from=builder /go/src/github.com/CESARBR/knot-babeltower/app-linux-amd64 app
+COPY --from=builder /go/src/github.com/CESARBR/knot-cloud-storage/app-linux-amd64 app
 
 ENTRYPOINT ["./app"]

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8181
 
 logger:
   level: debug


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch removes some references to babeltower in documentation. Also changes the storage development port and the docker build image tag to syncronize with new KNoT Cloud core stack

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 18.04.4

**NodeJS Version:** go1.13.8
