### PR TITLE
Add authentication

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,8 +10,7 @@ import (
 	"github.com/CESARBR/knot-cloud-storage/pkg/logging"
 	"github.com/CESARBR/knot-cloud-storage/pkg/network"
 	"github.com/CESARBR/knot-cloud-storage/pkg/server"
-
-	"os"
+	"github.com/CESARBR/knot-cloud-storage/pkg/users"
 )
 
 func main() {
@@ -33,8 +32,9 @@ func main() {
 	amqpStartChan := make(chan bool, 1)
 	amqp := network.NewAmqp(config.RabbitMQ.URL, logrus.Get("AMQP"))
 
+	usersService := users.New(config.Users.Host, config.Users.Port, logger)
 	dataStore := data.NewDataStore(database, logrus.Get("Storage"))
-	dataInteractor := interactor.NewDataInteractor(dataStore, logrus.Get("Interactor"))
+	dataInteractor := interactor.NewDataInteractor(usersService, dataStore, logrus.Get("Interactor"))
 	dataController := controllers.NewDataController(dataInteractor, logrus.Get("Controller"))
 
 	handlerStartChan := make(chan bool, 1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,12 +30,19 @@ type MongoDB struct {
 	Name string
 }
 
+// Users represents the users service configuration properties
+type Users struct {
+	Host string
+	Port int
+}
+
 // Config represents the service configuration
 type Config struct {
 	Server
 	Logger
 	RabbitMQ
 	MongoDB
+	Users
 }
 
 func readFile(name string) {

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -5,6 +5,10 @@ MongoDB:
   host: mongodb://mongo
   name: things_db
 
+Users:
+  host: localhost
+  port: 80
+
 rabbitmq:
   url: amqp://knot:knot@rabbitmq
 

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -5,6 +5,10 @@ MongoDB:
   host: mongodb://mongo
   name: things_db
 
+Users:
+  host: localhost
+  port: 8080
+
 rabbitmq:
   url: amqp://knot:knot@rabbitmq
 

--- a/pkg/interactor/data.go
+++ b/pkg/interactor/data.go
@@ -10,18 +10,22 @@ import (
 	"github.com/CESARBR/knot-cloud-storage/pkg/entities"
 	. "github.com/CESARBR/knot-cloud-storage/pkg/entities"
 	"github.com/CESARBR/knot-cloud-storage/pkg/logging"
+	"github.com/CESARBR/knot-cloud-storage/pkg/users"
 )
 
 // ErrTokenEmpty is returned for empty access tokens.
 var ErrTokenEmpty = errors.New("no access token provided")
 
+// DataInteractor represents the data layer interactor structure
 type DataInteractor struct {
-	DataStore *data.DataStore
-	logger    logging.Logger
+	UsersService users.Authenticator
+	DataStore    *data.DataStore
+	logger       logging.Logger
 }
 
-func NewDataInteractor(dataStore *data.DataStore, logger logging.Logger) *DataInteractor {
-	return &DataInteractor{dataStore, logger}
+// NewDataInteractor creates a new data interactor instance
+func NewDataInteractor(usersService users.Authenticator, dataStore *data.DataStore, logger logging.Logger) *DataInteractor {
+	return &DataInteractor{usersService, dataStore, logger}
 }
 
 // GetAll retrieves all the data present in the storage
@@ -87,6 +91,10 @@ func (d *DataInteractor) Save(token, id string, data []entities.Payload, timesta
 func (d *DataInteractor) Authenticate(token string) error {
 	if token == "" {
 		return ErrTokenEmpty
+	}
+	err := d.UsersService.Authenticate(token)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/interactor/data.go
+++ b/pkg/interactor/data.go
@@ -1,7 +1,6 @@
 package interactor
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -12,9 +11,6 @@ import (
 	"github.com/CESARBR/knot-cloud-storage/pkg/logging"
 	"github.com/CESARBR/knot-cloud-storage/pkg/users"
 )
-
-// ErrTokenEmpty is returned for empty access tokens.
-var ErrTokenEmpty = errors.New("no access token provided")
 
 // DataInteractor represents the data layer interactor structure
 type DataInteractor struct {
@@ -89,9 +85,6 @@ func (d *DataInteractor) Save(token, id string, data []entities.Payload, timesta
 
 // Authenticate verifies if the access token is valid.
 func (d *DataInteractor) Authenticate(token string) error {
-	if token == "" {
-		return ErrTokenEmpty
-	}
 	err := d.UsersService.Authenticate(token)
 	if err != nil {
 		return err

--- a/pkg/interactor/data.go
+++ b/pkg/interactor/data.go
@@ -1,6 +1,7 @@
 package interactor
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -10,6 +11,9 @@ import (
 	. "github.com/CESARBR/knot-cloud-storage/pkg/entities"
 	"github.com/CESARBR/knot-cloud-storage/pkg/logging"
 )
+
+// ErrTokenEmpty is returned for empty access tokens.
+var ErrTokenEmpty = errors.New("no access token provided")
 
 type DataInteractor struct {
 	DataStore *data.DataStore
@@ -58,6 +62,14 @@ func (d *DataInteractor) Save(id string, data []entities.Payload, timestamp time
 		}
 	}
 
+	return nil
+}
+
+// Authenticate verifies if the access token is valid.
+func (d *DataInteractor) Authenticate(token string) error {
+	if token == "" {
+		return ErrTokenEmpty
+	}
 	return nil
 }
 

--- a/pkg/interactor/data.go
+++ b/pkg/interactor/data.go
@@ -24,7 +24,13 @@ func NewDataInteractor(dataStore *data.DataStore, logger logging.Logger) *DataIn
 	return &DataInteractor{dataStore, logger}
 }
 
-func (d *DataInteractor) GetAll(order, skip, take int, startDate, finishDate time.Time) ([]Data, error) {
+// GetAll retrieves all the data present in the storage
+func (d *DataInteractor) GetAll(token string, order, skip, take int, startDate, finishDate time.Time) ([]Data, error) {
+	err := d.Authenticate(token)
+	if err != nil {
+		return nil, err
+	}
+
 	selectOrder := "timestamp"
 	if order == -1 {
 		selectOrder = "-timestamp"
@@ -37,7 +43,13 @@ func (d *DataInteractor) GetAll(order, skip, take int, startDate, finishDate tim
 	return data, err
 }
 
-func (d *DataInteractor) GetByID(id string, order, skip, take int, startDate, finishDate time.Time) ([]Data, error) {
+// GetByID retrieves data by it's ID from the storage, if present
+func (d *DataInteractor) GetByID(token, id string, order, skip, take int, startDate, finishDate time.Time) ([]Data, error) {
+	err := d.Authenticate(token)
+	if err != nil {
+		return nil, err
+	}
+
 	selectOrder := "timestamp"
 	if order == -1 {
 		selectOrder = "-timestamp"
@@ -54,9 +66,15 @@ func (d *DataInteractor) GetByID(id string, order, skip, take int, startDate, fi
 	return data, err
 }
 
-func (d *DataInteractor) Save(id string, data []entities.Payload, timestamp time.Time) error {
+// Save inserts data to the storage, if it doesn't exist already
+func (d *DataInteractor) Save(token, id string, data []entities.Payload, timestamp time.Time) error {
+	err := d.Authenticate(token)
+	if err != nil {
+		return err
+	}
+
 	for _, dt := range data {
-		err := d.DataStore.Save(Data{From: id, Payload: dt, Timestamp: timestamp})
+		err = d.DataStore.Save(Data{From: id, Payload: dt, Timestamp: timestamp})
 		if err != nil {
 			return fmt.Errorf("error saving data %v: %w", data, err)
 		}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -75,17 +75,17 @@ func (h *Handler) onMsgReceived(msgChan chan network.InMsg) {
 func (h *Handler) handleMessages(msg network.InMsg) error {
 	switch msg.RoutingKey {
 	case "data.publish":
-		return h.handlePublishData(msg.Body)
+		return h.handlePublishData(msg.Headers["Authorization"].(string), msg.Body)
 	}
 	return nil
 }
 
-func (h *Handler) handlePublishData(body []byte) error {
+func (h *Handler) handlePublishData(token string, body []byte) error {
 	msg := network.DataPublish{}
 	err := json.Unmarshal(body, &msg)
 	if err != nil {
 		return fmt.Errorf("message body parsing error: %w", err)
 	}
 
-	return h.dataInteractor.Save(msg.ID, msg.Data, time.Now())
+	return h.dataInteractor.Save(token, msg.ID, msg.Data, time.Now())
 }

--- a/pkg/users/service.go
+++ b/pkg/users/service.go
@@ -1,0 +1,35 @@
+package users
+
+import (
+	"fmt"
+
+	"github.com/CESARBR/knot-cloud-storage/pkg/logging"
+)
+
+// Authenticator specifies an API to use the service.
+type Authenticator interface {
+	Authenticate(token string) error
+}
+
+type service struct {
+	url    string
+	logger logging.Logger
+}
+
+// New creates a Users service instance.
+func New(host string, port int, logger logging.Logger) Authenticator {
+	return &service{
+		url:    fmt.Sprintf("http://%s:%d/%s", host, port, "users"),
+		logger: logger,
+	}
+}
+
+// Authenticate sends a request to the cloud to verify the access token.
+func (svc *service) Authenticate(token string) error {
+	err := svc.sendAuthRequest(token)
+	if err != nil {
+		svc.logger.Errorf("authentication request failed: %v", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/users/service.go
+++ b/pkg/users/service.go
@@ -1,10 +1,14 @@
 package users
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/CESARBR/knot-cloud-storage/pkg/logging"
 )
+
+// ErrTokenEmpty is returned for empty access tokens.
+var ErrTokenEmpty = errors.New("no access token provided")
 
 // Authenticator specifies an API to use the service.
 type Authenticator interface {
@@ -26,10 +30,15 @@ func New(host string, port int, logger logging.Logger) Authenticator {
 
 // Authenticate sends a request to the cloud to verify the access token.
 func (svc *service) Authenticate(token string) error {
+	if token == "" {
+		return ErrTokenEmpty
+	}
+
 	err := svc.sendAuthRequest(token)
 	if err != nil {
 		svc.logger.Errorf("authentication request failed: %v", err)
 		return err
 	}
+
 	return nil
 }

--- a/pkg/users/transport.go
+++ b/pkg/users/transport.go
@@ -1,0 +1,54 @@
+package users
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+var (
+	// ErrBadRequest is returned when query parameters are missing or invalid.
+	ErrBadRequest = errors.New("failed due to malformed query parameters")
+
+	// ErrTokenInvalid is returned when the access token isn't registered in the cloud.
+	ErrTokenInvalid = errors.New("invalid access token provided")
+
+	// ErrServerUnexpected is returned when the server is responsible for the error.
+	ErrServerUnexpected = errors.New("unexpected server-side error occurred")
+
+	// ErrUnknown is returned when the error is none of the above.
+	ErrUnknown = errors.New("unknown error")
+)
+
+func (svc *service) sendAuthRequest(token string) error {
+	req, err := http.NewRequest("GET", svc.url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", token)
+	client := &http.Client{Timeout: time.Second * 10}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return svc.getResponse(resp.StatusCode)
+}
+
+func (svc *service) getResponse(statusCode int) error {
+	switch statusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusBadRequest:
+		return ErrBadRequest
+	case http.StatusForbidden:
+		return ErrTokenInvalid
+	case http.StatusInternalServerError:
+		return ErrServerUnexpected
+	default:
+		return ErrUnknown
+	}
+}


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:** 
(if necessary, link currently open issues with [special keywords](https://help.github.com/en/articles/closing-issues-using-keywords))

- Add user authentication to the available operations. 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
API consumers must send the [User Access Token (a.k.a. Authorization Key)](https://mainflux.readthedocs.io/en/latest/provisioning/#obtaining-an-authorization-key) in the `Authorization` Header, in order to successfully post and retrieve data.

**The PR fulfills these requirements:**

- [X] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: Linux 5.5.13-arch2-1 x86_64 :computer: 
- Go version: go1.14.1 :rocket: 

If you have relevant logs, error output and etc, please attach them.

**Other information:**

Although this PR can be further improved, most of the changes required code code structure changes that are being addressed in pr #15. Applying these changes would imply in quite some rework. For this reason, sticking to the standard of the previous commits seemed a better approach -- so that when pr #15 is integrated, refactoring will be less overwhelming. 

Also, this PR is related to task [BLI-75](https://jira.cesar.org.br/browse/BLI-75) :confetti_ball: 