### PR TITLE
fix: Update dockerfiles to GOPROXY and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,4 @@ clean:
 	$(GOCLEAN)
 	@rm -f ${BINARY}-$(OS)-${GOARCH}
 	@rm -f coverage.out
-
-.PHONY: deps
-deps:
-	go mod download
-	go mod vendor
+	@rm -rf vendor

--- a/README.md
+++ b/README.md
@@ -2,15 +2,28 @@
 
 A web server that receives messages forwarded by devices and stores them in a database. This service is currently being rewritten in golang to become suitable for running on constrained boards. The legacy instructions can be seen [here](legacy/LEGACY.md).
 
-## Installation and usage
+## Contents
+
+- [Basic installation and usage](#basic-installation-and-usage)
+  - [Requirements](#requirements)
+  - [Configuration](#configuration)
+  - [Setup](#setup)
+  - [Compiling and Running](#compiling-and-running)
+- [Docker installation and usage](#docker-installation-and-usage)
+  - [Building and Running](#building-and-running)
+    - [Production](#production)
+    - [Development](#development)
+- [Verify service health](#verify-service-health)
+
+## Basic installation and usage
 
 ### Requirements
 
-*   Go version 1.13+.
-*   Be sure the local packages binaries path is in the system's `PATH` environment variable:
+- Go version 1.13+.
+- Be sure the local packages binaries path is in the system's `PATH` environment variable:
 
 ```bash
-$ export PATH=$PATH:<your_go_workspace>/bin
+export PATH=$PATH:<your_go_workspace>/bin
 ```
 
 ### Configuration
@@ -19,14 +32,13 @@ You can set the `ENV` environment variable to `development` and update the `inte
 
 The configuration parameters are the following (the environment variable name is in parenthesis):
 
-*   `server`
-    *   `port` (`SERVER_PORT`) **Number** Server port number. (Default: 80)
+- `server`
+  - `port` (`SERVER_PORT`) **Number** Server port number. (Default: 80)
 
 ### Setup
 
 ```bash
 make tools
-make deps
 ```
 
 ### Compiling and running
@@ -35,44 +47,48 @@ make deps
 make run
 ```
 
-## Local (Development)
+> You can use the `make watch` command to run the application on watching mode, allowing it to be restarted automatically when the code changes.
 
-### Build and run (Docker)
+## Docker installation and usage
+
+Make sure you have [Docker Engine](<https://docs.docker.com/install/>) installed.
+
+### Building and Running
 
 #### Production
 
 A container is specified at `docker/Dockerfile`. To use it, execute the following steps:
 
-01. Build the image:
+1. Build the image:
 
     ```bash
-    docker build . -f docker/Dockerfile -t cesarbr/knot-cloud-storage
+    docker build . -f docker/Dockerfile -t cesarbr/knot-cloud-storage:dev-go
     ```
 
-01. Create a file containing the configuration as environment variables.
+2. Create a file containing the configuration as environment variables.
 
-01. Run the container:
+3. Run the container:
 
     ```bash
-    docker run --env-file knot-cloud-storage.env -ti cesarbr/knot-cloud-storage
+    docker run --env-file knot-cloud-storage.env -ti cesarbr/knot-cloud-storage:dev-go
     ```
 
 #### Development
 
 A development container is specified at `docker/Dockerfile-dev`. To use it, execute the following steps:
 
-01. Build the image:
+1. Build the image:
 
     ```bash
-    docker build . -f docker/Dockerfile-dev -t cesarbr/knot-cloud-storage-go:dev
+    docker build . -f docker/Dockerfile-dev -t cesarbr/knot-cloud-storage-go:dev-go
     ```
 
-01. Create a file containing the configuration as environment variables.
+2. Create a file containing the configuration as environment variables.
 
-01. Run the container:
+3. Run the container:
 
     ```bash
-    docker run --env-file knot-cloud-storage.env -p 8080:80 -v `pwd`:/usr/src/app -ti cesarbr/knot-cloud-storage-go:dev
+    docker run --env-file knot-cloud-storage.env -p 8080:80 -v `pwd`:/usr/src/app -ti cesarbr/knot-cloud-storage-go:dev-go
     ```
 
 The first argument to -v must be the root of this repository, so if you are running from another folder, replace `pwd` with the corresponding path.
@@ -82,6 +98,7 @@ This will start the server with auto-reload.
 ## Verify service health
 
 ### Verify
+
 ```bash
 curl http://<hostname>:<port>/healthcheck
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,8 @@
 # First stage: build the application
 FROM golang:1.14-alpine AS builder
+
 ARG GOARCH
 ARG GOARM
-
-# Set the Current Working Directory inside the container
-WORKDIR /go/src/github.com/CESARBR/knot-cloud-storage
-
-# Copy the source code from the current directory to $WORKDIR (inside the container)
-COPY . .
 
 # Install build utilities
 RUN apk --no-cache add --virtual .build-deps \
@@ -20,9 +15,14 @@ RUN apk --no-cache add \
     ca-certificates \
     && update-ca-certificates
 
+# Set the Current Working Directory inside the container
+WORKDIR /go/src/github.com/CESARBR/knot-cloud-storage
+
+# Copy the source code from the current directory to $WORKDIR (inside the container)
+COPY . .
+
 # Install project development tools and dependencies
 RUN go get github.com/ahmetb/govvv
-RUN make deps
 
 # Build the application
 RUN make bin
@@ -32,6 +32,7 @@ RUN apk del .build-deps
 
 # Second stage: create the entrypoint to the application binary generated in the previous stage
 FROM scratch
+
 WORKDIR /root/
 
 # Copy the configuration files from the build stage

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -5,7 +5,7 @@ COPY . .
 
 RUN apk add --update make
 RUN go get github.com/cespare/reflex
-RUN go mod download
+RUN go get ./...
 
 ENV "ENV" "development"
 CMD [ "make", "watch"]


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:** (if necessary, link currently open issues with [special keywords](https://help.github.com/en/articles/closing-issues-using-keywords))

- Create an image from `scratch` on the second stage, in order to reduce final binary size (originally from [this discussion](https://github.com/CESARBR/knot-cloud-storage/pull/13#discussion_r394023934))
- Use [`GOPROXY`]() as default (in opposition to VCS and vendoring) 
- Remove `make go deps` from README 
- Fix markdown errors in README, as well as make other adjustments. 

>These changes were originally made in the `knot-babeltower` repo's [pr #56](https://github.com/CESARBR/knot-babeltower/pull/56).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [x] Other, please describe: Documentation update and fix.

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

N/A :confetti_ball: 

**The PR fulfills these requirements:**

- [x] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

**Testing environment:**

- Operating System/Platform: N/A 
- Node version: N/A
- Yarn version: N/A  

If you have relevant logs, error output and etc, please attach them.

**Other information:**

N/A