### PR TITLE
Exit when database connection fails

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,8 @@ import (
 	"github.com/CESARBR/knot-cloud-storage/pkg/interactor"
 	"github.com/CESARBR/knot-cloud-storage/pkg/logging"
 	"github.com/CESARBR/knot-cloud-storage/pkg/server"
+
+	"os"
 )
 
 func main() {
@@ -19,7 +21,8 @@ func main() {
 	mongo := data.NewMongoDB(config.MongoDB.Host, config.MongoDB.Name)
 	database, err := mongo.Connect()
 	if err != nil {
-		logger.Error(err)
+		logger.Error("Failed to connect with the database: ", err)
+		os.Exit(1)
 	}
 
 	dataStore := data.NewDataStore(database, logrus.Get("Storage"))


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch aims to stop the service gracefully when failed to connect with the database. Further investigations can be applied in order to enable reconnection.

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Any other comments?
-------------------
Nops.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS 10.14 - Darwin 18.0.0

**Go version:** 1.14
