### PR TITLE
data: Update data handler to listen new event

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gorilla/mux v1.7.4
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.6.2
 	github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -55,8 +55,8 @@ func (a *Amqp) Stop() {
 }
 
 // OnMessage receive messages and put them on channel
-func (a *Amqp) OnMessage(msgChan chan InMsg, queueName, exchangeName, key string) error {
-	err := a.declareExchange(exchangeName)
+func (a *Amqp) OnMessage(msgChan chan InMsg, queueName, exchangeName, exchangeType, key string) error {
+	err := a.declareExchange(exchangeName, exchangeType)
 	if err != nil {
 		a.logger.Error(err)
 		return err
@@ -137,15 +137,15 @@ func (a *Amqp) notifyWhenClosed(started chan bool) {
 	}
 }
 
-func (a *Amqp) declareExchange(name string) error {
+func (a *Amqp) declareExchange(name, exchangeType string) error {
 	return a.channel.ExchangeDeclare(
 		name,
-		amqp.ExchangeTopic, // type
-		true,               // durable
-		false,              // delete when complete
-		false,              // internal
-		false,              // noWait
-		nil,                // arguments
+		exchangeType,
+		true,  // durable
+		false, // delete when complete
+		false, // internal
+		false, // noWait
+		nil,   // arguments
 	)
 }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
As the KNot Cloud core API changed recently, data messages are now coming through `data.published` events, which can be received via fanout exchange with the same name. In order to support this new scenario, this patch updates the amqp and handler operations to enable receiving broadcasted messages. Also, it validates if authorization token is correctly provided and log when data is successfully saved.

Does this close any currently open issues?
Nops.

Where has this been tested?
---------------------------

**Operating System/Platform:** macOS Darwin 18.0.0

**Go Version:** 1.14
