### PR TITLE
mongo: Increase the timeout for a connection

### DIFF
--- a/pkg/data/mongo.go
+++ b/pkg/data/mongo.go
@@ -2,11 +2,15 @@ package data
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
+
+// CONNECTIONTIMEOUT is a constant to set the waiting time for a database connection
+const connectionTimeout = 60 * time.Second
 
 type MongoDB struct {
 	Server   string
@@ -18,7 +22,9 @@ func NewMongoDB(server string, database string) *MongoDB {
 }
 
 func (s *MongoDB) Connect() (*mongo.Database, error) {
-	clientOptions := options.Client().ApplyURI(s.Server)
+	clientOptions := options.Client()
+	clientOptions.ApplyURI(s.Server)
+	clientOptions.SetConnectTimeout(connectionTimeout)
 	client, err := mongo.NewClient(clientOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request implements unit tests for all interactor features.

- Adds the connection timeout configuration

Does this close any currently open issues?
------------------------------------------
Any relevant logs, error output, etc?
-------------------------------------
Any other comments?
-------------------
Where has this been tested?
---------------------------

**Operating System/Platform:** MACOS Catalina

**GO Version:** go 1.13.7 darwin/amd64

