### PR TITLE
Fix thing's service hostname and port

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 	amqpStartChan := make(chan bool, 1)
 	amqp := network.NewAmqp(config.RabbitMQ.URL, logrus.Get("AMQP"))
 
-	thingsService := things.New(config.Users.Host, uint16(config.Users.Port), logger)
+	thingsService := things.New(config.Things.Host, uint16(config.Things.Port), logger)
 	dataStore := data.NewStore(database, logrus.Get("Storage"))
 	dataInteractor := interactor.NewDataInteractor(thingsService, dataStore, logrus.Get("Interactor"))
 	dataController := controllers.NewDataController(dataInteractor, logrus.Get("Controller"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,8 +30,8 @@ type MongoDB struct {
 	Name string
 }
 
-// Users represents the users service configuration properties
-type Users struct {
+// Things represents the things service configuration properties
+type Things struct {
 	Host string
 	Port int
 }
@@ -42,7 +42,7 @@ type Config struct {
 	Logger
 	RabbitMQ
 	MongoDB
-	Users
+	Things
 }
 
 func readFile(name string) {

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -1,11 +1,11 @@
 server:
   port: 80
 
-MongoDB:
+mongodb:
   host: mongodb://mongo
   name: things_db
 
-Users:
+things:
   host: localhost
   port: 80
 

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -1,13 +1,13 @@
 server:
   port: 8181
 
-MongoDB:
+mongodb:
   host: mongodb://mongo
   name: things_db
 
-Users:
-  host: localhost
-  port: 8080
+things:
+  host: things
+  port: 8182
 
 rabbitmq:
   url: amqp://knot:knot@rabbitmq


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch fixes the hostname and port for things service in configuration files

Where has this been tested?
---------------------------
**Operating System/Platform:** 18.04
**NPM Version:** 6.14
**NodeJS Version:** 12.15
