### PR TITLE
mongo: Add TTL to expire data after specified time

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,8 @@ func main() {
 	amqp := network.NewAmqp(config.RabbitMQ.URL, logrus.Get("AMQP"))
 
 	thingsService := things.New(config.Things.Host, uint16(config.Things.Port), logger)
-	dataStore := data.NewStore(database, logrus.Get("Storage"))
+	dataStore := data.NewStore(database, logrus.Get("Storage"), config.Expiration.Time)
+
 	dataInteractor := interactor.NewDataInteractor(thingsService, dataStore, logrus.Get("Interactor"))
 	dataController := controllers.NewDataController(dataInteractor, logrus.Get("Controller"))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,11 @@ type Things struct {
 	Port int
 }
 
+// Expiration represents the data TTL configuration
+type Expiration struct {
+	Time int32
+}
+
 // Config represents the service configuration
 type Config struct {
 	Server
@@ -43,6 +48,7 @@ type Config struct {
 	RabbitMQ
 	MongoDB
 	Things
+	Expiration
 }
 
 func readFile(name string) {

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -14,3 +14,6 @@ rabbitmq:
 
 logger:
   level: info
+
+expiration:
+  time: 0

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -14,3 +14,6 @@ rabbitmq:
 
 logger:
   level: debug
+
+expiration:
+  time: 604800


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds a TTL index to expire data after a specified time. This will be useful to avoid storing data forever on constrained devices.

Does this close any currently open issues?
------------------------------------------
nops.

Any relevant logs, error output, etc?
-------------------------------------
nops.

Any other comments?
-------------------
nops.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS - Darwin 18.0.0

**Go version:** 1.14

