### PR TITLE
logger: Enable syslog via unix socket

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	config := config.Load()
 
-	logrus := logging.NewLogrus(config.Logger.Level)
+	logrus := logging.NewLogrus(config.Logger.Level, config.Logger.Syslog)
 	logger := logrus.Get("Main")
 	logger.Info("Starting KNoT Cloud Storage")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,8 @@ type Server struct {
 
 // Logger represents the logger configuration properties
 type Logger struct {
-	Level string
+	Level  string
+	Syslog bool
 }
 
 // RabbitMQ represents the rabbitmq configuration properties
@@ -52,7 +53,7 @@ type Config struct {
 }
 
 func readFile(name string) {
-	logger := logging.NewLogrus("error").Get("Config")
+	logger := logging.NewLogrus("error", false).Get("Config")
 	viper.SetConfigName(name)
 	if err := viper.ReadInConfig(); err != nil {
 		logger.Fatalf("Error reading config file, %s", err)
@@ -62,7 +63,7 @@ func readFile(name string) {
 // Load returns the service configuration
 func Load() Config {
 	var configuration Config
-	logger := logging.NewLogrus("error").Get("Config")
+	logger := logging.NewLogrus("error", false).Get("Config")
 	viper.AddConfigPath("internal/config")
 	viper.SetConfigType("yaml")
 

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -14,6 +14,7 @@ rabbitmq:
 
 logger:
   level: info
+  syslog: false
 
 expiration:
   time: 0

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -14,6 +14,7 @@ rabbitmq:
 
 logger:
   level: debug
+  syslog: false
 
 expiration:
   time: 604800

--- a/pkg/logging/logrus.go
+++ b/pkg/logging/logrus.go
@@ -1,19 +1,22 @@
 package logging
 
 import (
+	"log/syslog"
 	"os"
 
 	"github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 // Logrus represents the logrus logger
 type Logrus struct {
-	level string
+	level  string
+	syslog bool
 }
 
 // NewLogrus creates a new logrus instance
-func NewLogrus(level string) *Logrus {
-	return &Logrus{level: level}
+func NewLogrus(level string, syslog bool) *Logrus {
+	return &Logrus{level, syslog}
 }
 
 // Get returns a logrus instance based on the specific context
@@ -27,9 +30,27 @@ func (l *Logrus) Get(context string) *logrus.Entry {
 		TimestampFormat: "2006-01-02 15:04:05",
 	})
 
+	if l.syslog {
+		setupSyslog(log)
+	}
+
 	logger := log.WithFields(logrus.Fields{
 		"Context": context,
 	})
 
 	return logger
+}
+
+func setupSyslog(log *logrus.Logger) {
+	hook, err := logrus_syslog.NewSyslogHook("", "", syslog.LOG_INFO, "storage")
+	if err != nil {
+		log.Error("Unable to connect to local syslog daemon")
+		return
+	}
+
+	log.AddHook(hook)
+	log.SetFormatter(&logrus.TextFormatter{
+		DisableColors: true,
+		FullTimestamp: false,
+	})
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In order to facilitate the service monitoring when running on the RPi this patch enables redirecting logs to the syslog via unix socket protocol.

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Any other comments?
-------------------
Nops.

Where has this been tested?
---------------------------

**Operating System/Platform:** macOS Darwin 18.0.0

**Go Version:** 1.14