### PR TITLE
thing: Delete all data when thing unregistered

### DIFF
--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -9,3 +9,8 @@ type DataPublish struct {
 	ID   string             `json:"id"`
 	Data []entities.Payload `json:"data"`
 }
+
+// DeviceUnregistered represents the incoming unregistered device event
+type DeviceUnregistered struct {
+	ID string `json:"id"`
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR delete all the data associated with a thing that was unregistered from the cloud service.

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS Darwin - 18.0.0

**Go Version:** 1.14