### PR TITLE
Reduce requests to Mainflux

### DIFF
--- a/pkg/interactor/interactor.go
+++ b/pkg/interactor/interactor.go
@@ -16,12 +16,14 @@ type Interactor interface {
 
 // DataInteractor represents the data layer interactor structure
 type DataInteractor struct {
-	things    things.Lister
-	DataStore data.Store
-	logger    logging.Logger
+	things     things.Lister
+	DataStore  data.Store
+	logger     logging.Logger
+	tokenCache map[string]struct{}
 }
 
 // NewDataInteractor creates a new data interactor instance
 func NewDataInteractor(things things.Lister, dataStore data.Store, logger logging.Logger) Interactor {
-	return &DataInteractor{things, dataStore, logger}
+	cache := make(map[string]struct{})
+	return &DataInteractor{things, dataStore, logger, cache}
 }

--- a/pkg/interactor/save_data.go
+++ b/pkg/interactor/save_data.go
@@ -8,17 +8,23 @@ import (
 
 // Save inserts data to the storage, if it doesn't exist already
 func (d *DataInteractor) Save(token, id string, data []entities.Payload) error {
-	_, err := d.things.List(token)
-	if err != nil {
-		return fmt.Errorf("%v: %w", ErrValidToken, err)
-	}
-
-	for _, dt := range data {
-		err = d.DataStore.Save(entities.Data{From: id, Payload: dt})
+	_, ok := d.tokenCache[token]
+	if ok {
+		return nil
+	} else {
+		_, err := d.things.List(token)
 		if err != nil {
-			return fmt.Errorf("error saving data %v: %w", data, err)
+			return fmt.Errorf("%v: %w", ErrValidToken, err)
 		}
-	}
+		// Updates the cache to signal the existence of the token.
+		d.tokenCache[token] = struct{}{}
+		for _, dt := range data {
+			err = d.DataStore.Save(entities.Data{From: id, Payload: dt})
+			if err != nil {
+				return fmt.Errorf("error saving data %v: %w", data, err)
+			}
+		}
 
-	return nil
+		return nil
+	}
 }


### PR DESCRIPTION
(Thanks for sending a pull request! Please fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR reduces the number of requests to Mainflux's things service, which significantly increases storage scalability. With this update, storage will no longer need to query the things service for every message to be stored.

Does this close any currently open issues?
------------------------------------------
(Use the special github keywords to reference issues: https://help.github.com/en/articles/closing-issues-using-keywords)

...

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://pastebin.com/ and insert the link here.)

Any other comments?
-------------------
...

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** ...
Ubuntu 20.04.
**NPM Version:** ...

**NodeJS Version:** ...

(Add more information here if needed.)
